### PR TITLE
UNIX socket support implementation for SOCKS5 server

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ To run SOCKS proxy server listening on local port 1080 using generated configura
 ./yggstack -useconffile /path/to/yggdrasil.conf -socks 127.0.0.1:1080
 ```
 
+To run SOCKS proxy server listening on UNIX socket file `/tmp/yggstack.sock`:
+
+```
+./yggstack -useconffile /path/to/yggdrasil.conf -socks /tmp/yggstack.sock
+```
+
 To expose network services (like a Web server) listening on local port 8080 to Yggdrasil
 network address at port 80:
 


### PR DESCRIPTION
This pull request introduces UNIX socket support for the SOCKS5 server in the `yggstack` command and updates the `README.md` with the corresponding usage instructions.

Key changes include:

UNIX Socket Support: The `yggstack` command now supports UNIX sockets for the SOCKS5 server. This allows for more secure and efficient communication between local processes.

Updated Documentation: The `README.md` file has been updated with instructions on how to use the new UNIX socket support. It includes command for running a SOCKS proxy server listening on a UNIX socket file and for exposing network services to the Yggdrasil network.

These changes enhance the flexibility and usability of the Yggstack command, allowing it to be used in more diverse networking environments.

Please review the changes and provide any feedback.

Thank you.