### PR TITLE
Add missing PacketBuffer DecRef() calls to prevent crashes

### DIFF
--- a/src/netstack/yggdrasil.go
+++ b/src/netstack/yggdrasil.go
@@ -49,15 +49,17 @@ func (s *YggdrasilNetstack) NewYggdrasilNIC(ygg *core.Core) tcpip.Error {
 				Payload: buffer.MakeWithData(nic.readBuf[:rx]),
 			})
 			nic.dispatcher.DeliverNetworkPacket(ipv6.ProtocolNumber, pkb)
+			pkb.DecRef()
 		}
 	}()
 	go func() {
 		for {
-			pkt := <- nic.rstPackets
+			pkt := <-nic.rstPackets
 			if pkt == nil {
 				continue
 			}
 			_ = nic.writePacket(pkt)
+			pkt.DecRef()
 		}
 	}()
 	_, snet, err := net.ParseCIDR("0200::/7")
@@ -142,7 +144,14 @@ func (e *YggdrasilNIC) WritePackets(
 			if pkt.Network().TransportProtocol() == tcp.ProtocolNumber {
 				tcpHeader := header.TCP(pkt.TransportHeader().Slice())
 				if (tcpHeader.Flags() & header.TCPFlagRst) == header.TCPFlagRst {
-					e.rstPackets <- pkt
+					pkt.IncRef()
+					select {
+					case e.rstPackets <- pkt:
+						// Packet queued successfully
+					default:
+						// Channel full, drop packet and release ref
+						pkt.DecRef()
+					}
 					continue
 				}
 			}


### PR DESCRIPTION
Fixes a critical memory management bug in the gVisor netstack integration that caused immediate application crashes due to incorrect PacketBuffer reference counting. Missing DecRef() calls were added in key packet processing paths to prevent reference count panics (Incrementing/Decrementing non-positive ref count) and SIGABRT crashes.


## How to reproduce:
Run nmap port scanner against yggstack node. Result - 100% app crush.

### Crash Evidence
From logcat analysis:
- **Process ID 21083** crashed at 22:04:37 with: `panic: Decrementing non-positive ref count 0x4000348c60`
- **Process ID 22071** crashed at 22:04:45 with: `panic: Incrementing non-positive count 0x400007e7c0`
- Both crashes occurred in `runtime.DefaultDispatch` threads during buffer operations
- Tombstone files generated: `tombstone_23` and `tombstone_24`


## Comment
We got this behavior on yggstack-android app (https://github.com/DrewCyber/yggstack-android) v0.1.22.
After this fix app works 100% correctly (v.0.1.23).
