### PR TITLE
Fix handling of incoming packets from Yggdrasil network

### DIFF
--- a/src/netstack/yggdrasil.go
+++ b/src/netstack/yggdrasil.go
@@ -22,6 +22,7 @@ type YggdrasilNIC struct {
 	readBuf    []byte
 	writeBuf   []byte
 	rstPackets chan *stack.PacketBuffer
+	packetQueue chan []byte
 }
 
 func (s *YggdrasilNetstack) NewYggdrasilNIC(ygg *core.Core) tcpip.Error {
@@ -32,6 +33,7 @@ func (s *YggdrasilNetstack) NewYggdrasilNIC(ygg *core.Core) tcpip.Error {
 		readBuf:    make([]byte, mtu),
 		writeBuf:   make([]byte, mtu),
 		rstPackets: make(chan *stack.PacketBuffer, 100),
+		packetQueue: make(chan []byte, 1000),
 	}
 	if err := s.stack.CreateNIC(1, nic); err != nil {
 		return err
@@ -45,8 +47,21 @@ func (s *YggdrasilNetstack) NewYggdrasilNIC(ygg *core.Core) tcpip.Error {
 				log.Println(err)
 				break
 			}
+
+			packet := make([]byte, rx)
+			copy(packet, nic.readBuf[:rx])
+
+			select {
+			case nic.packetQueue <- packet:
+			default:
+				log.Println("Packet queue full, dropping packet")
+			}
+		}
+	}()
+	go func() {
+		for packet := range nic.packetQueue {
 			pkb := stack.NewPacketBuffer(stack.PacketBufferOptions{
-				Payload: buffer.MakeWithData(nic.readBuf[:rx]),
+				Payload: buffer.MakeWithData(packet),
 			})
 			nic.dispatcher.DeliverNetworkPacket(ipv6.ProtocolNumber, pkb)
 			pkb.DecRef()


### PR DESCRIPTION
This fix touches this issue: https://github.com/yggdrasil-network/yggstack/issues/8

How to reproduce this: simultaneously perform an infinite ping to the IPv6 yggstack address and start transmitting data over the Yggdrasil network

This is actually a Denial of Service attack on any yggstack node using simple ICMP echo-request packets :)

Tested on various platforms: linux-amd64, linux-arm64, linux-armv7, windows-amd64
Everything seems to be working fine